### PR TITLE
Add health EICAR Infected Validation flag to configurations

### DIFF
--- a/config/default.sample.yaml
+++ b/config/default.sample.yaml
@@ -12,6 +12,9 @@ clamd:
     host: localhost
     port: 3310
 
+health:
+    eicarInfectedValidation: true # enforce the EICAR string to recognize as infected by the AV engine, defaults to true
+    
 storage: s3 # supports only s3 currently
 
 dynamodb:

--- a/scanner/index.js
+++ b/scanner/index.js
@@ -189,9 +189,17 @@ const isClamdHealthy = async () => {
         _logger.debug({ step: "scan_test_stream" })
         const { is_infected } = await _clamscan.scan_stream(virusStream);
         _logger.debug({ step: "scan_test_stream", is_infected, success: true })
-
-        if (!is_infected)
+        
+        let eicarInfectedValidation;
+        if (config.has('health.eicarInfectedValidation')) {
+            eicarInfectedValidation = config.get('health.eicarInfectedValidation');
+        } else {
+            eicarInfectedValidation = true;
+        } 
+                
+        if (!is_infected && eicarInfectedValidation) {
             return false;
+        }
 
         return true;
     } catch (error) {


### PR DESCRIPTION
Enforce the EICAR string to recognize as infected by the AV engine to pass the healthcheck, defaults to true. Created due to issues as https://bugzilla.clamav.net/show_bug.cgi?id=12667. 